### PR TITLE
hydra wont support multiple pods using the same db at once

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "2.9.3-1-01"
 description: NZBHydra 2 is a meta search for NZB indexers. It provides easy access to a number of raw and newznab based indexers. You can search all your indexers from one place and use it as an indexer source for tools like Sonarr, Radarr or CouchPotato.
 name: nzbhydra2
-version: 2.9.4
+version: 2.9.5
 keywords:
   - nzbhydra2
 home: https://www.nzbhydra2.org/

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "nzbhydra2.name" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,9 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# upgrade strategy type (e.g. Recreate or RollingUpdate)
+strategyType: Recreate
+
 service:
   type: ClusterIP
   port: 5076


### PR DESCRIPTION
RollingUpdate prevents automated updates with tools such as flux.

Signed-off-by: Ryan Holt <ryan@ryanholt.net>