### PR TITLE
add deploymentannotations and bump chart version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "2.13.2-1-01"
 description: NZBHydra 2 is a meta search for NZB indexers. It provides easy access to a number of raw and newznab based indexers. You can search all your indexers from one place and use it as an indexer source for tools like Sonarr, Radarr or CouchPotato.
 name: nzbhydra2
-version: 2.13.2
+version: 2.13.3
 keywords:
   - nzbhydra2
 home: https://www.nzbhydra2.org/

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,6 +2,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "nzbhydra2.fullname" . }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := .Values.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "nzbhydra2.name" . }}
     helm.sh/chart: {{ include "nzbhydra2.chart" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -69,3 +69,5 @@ persistence:
     - ReadWriteOnce
   size: 8Gi
 podAnnotations: {}
+
+deploymentAnnotations: {}


### PR DESCRIPTION
Enables the use of operators that trigger off of deployment annotations, IE: Stash, istio, etc.

Signed-off-by: Ryan Holt <ryan@ryanholt.net>